### PR TITLE
Implement null safety and reflect that in pubspec

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -80,8 +80,8 @@ class _MyHomePageState extends State<MyHomePage> {
                   _incrementCounter();
                 },
                 builder: (BuildContext context, TapDebouncerFunc onTap) {
-                  return RaisedButton(
-                    color: Colors.blue,
+                  return ElevatedButton(
+                    style: ElevatedButton.styleFrom(primary: Colors.blue),
                     onPressed: onTap,
                     // variant with manual test onTap for null in builder
                     child: onTap == null
@@ -109,8 +109,8 @@ class _MyHomePageState extends State<MyHomePage> {
                   );
                 },
                 builder: (BuildContext context, TapDebouncerFunc onTap) {
-                  return RaisedButton(
-                    color: Colors.green,
+                  return ElevatedButton(
+                    style: ElevatedButton.styleFrom(primary: Colors.green),
                     onPressed: onTap,
                     child: const Center(child: Text('Long')),
                   );
@@ -139,8 +139,8 @@ class _MyHomePageState extends State<MyHomePage> {
                   _incrementCounter();
                 },
                 builder: (BuildContext context, TapDebouncerFunc onTap) {
-                  return RaisedButton(
-                    color: Colors.pink,
+                  return ElevatedButton(
+                    style: ElevatedButton.styleFrom(primary: Colors.pink),
                     onPressed: onTap,
                     child: const Text('OneShot'),
                   );
@@ -169,7 +169,7 @@ class _MyHomePageState extends State<MyHomePage> {
                       try {
                         throw Exception('Some error');
                       } on Exception catch (error) {
-                        Scaffold.of(context).showSnackBar(SnackBar(
+                        ScaffoldMessenger.of(context).showSnackBar(SnackBar(
                           backgroundColor: Colors.red.withAlpha(0x80),
                           content: Text('Caught $error'),
                           duration: const Duration(milliseconds: 500),
@@ -177,8 +177,8 @@ class _MyHomePageState extends State<MyHomePage> {
                       }
                     },
                     builder: (BuildContext context, TapDebouncerFunc onTap) {
-                      return RaisedButton(
-                        color: Colors.red,
+                      return ElevatedButton(
+                        style: ElevatedButton.styleFrom(primary: Colors.red),
                         onPressed: onTap,
                         child: Center(
                             child: onTap == null
@@ -202,8 +202,8 @@ class _MyHomePageState extends State<MyHomePage> {
                 child: TapDebouncer(
                   onTap: null,
                   builder: (BuildContext context, TapDebouncerFunc onTap) {
-                    return RaisedButton(
-                      color: Colors.black26,
+                    return ElevatedButton(
+                      style: ElevatedButton.styleFrom(primary: Colors.black26),
                       onPressed: onTap,
                       child: const Text('Null'),
                     );
@@ -217,25 +217,25 @@ class _MyHomePageState extends State<MyHomePage> {
     );
   }
 
-  void _startCooldownIndicator(int time_ms) {
+  void _startCooldownIndicator(int timeMs) {
     _cooldownStarted = DateTime.now().millisecondsSinceEpoch;
-    _updateCooldown(time_ms);
+    _updateCooldown(timeMs);
   }
 
-  void _updateCooldown(int time_ms) {
+  void _updateCooldown(int timeMs) {
     final int current = DateTime.now().millisecondsSinceEpoch;
     int delta = current - _cooldownStarted;
-    if (delta > time_ms) {
-      delta = time_ms;
+    if (delta > timeMs) {
+      delta = timeMs;
     }
 
     setState(() {
-      _cooldown = delta.roundToDouble() / time_ms;
+      _cooldown = delta.roundToDouble() / timeMs;
     });
 
     Future<void>(() {
-      if (delta < time_ms) {
-        _updateCooldown(time_ms);
+      if (delta < timeMs) {
+        _updateCooldown(timeMs);
       } else {
         setState(() {
           _cooldown = 0.0;

--- a/lib/src/debouncer_widget.dart
+++ b/lib/src/debouncer_widget.dart
@@ -7,8 +7,8 @@ typedef TapDebouncerFunc = Future<void> Function();
 /// Tap debouncer widget
 class TapDebouncer extends StatefulWidget {
   const TapDebouncer({
-    Key key,
-    @required this.builder,
+    Key? key,
+    required this.builder,
     this.waitBuilder,
     this.onTap,
     this.cooldown,
@@ -21,18 +21,18 @@ class TapDebouncer extends StatefulWidget {
   /// Main button builder function
   /// context is current context
   /// onTap is function to pass to SomeButton or InkWell
-  final Widget Function(BuildContext context, TapDebouncerFunc onTap) builder;
+  final Widget Function(BuildContext context, TapDebouncerFunc? onTap) builder;
 
   /// Waiting button builder function
   /// context is current context
   /// child is widget returning from builder method with onTap equal null
-  final Widget Function(BuildContext context, Widget child) waitBuilder;
+  final Widget Function(BuildContext context, Widget child)? waitBuilder;
 
   /// Function to call on tap
-  final Future<void> Function() onTap;
+  final Future<void> Function()? onTap;
 
   /// Cooldown duration - delay after onTap executed (successfully or not)
-  final Duration cooldown;
+  final Duration? cooldown;
 
   @override
   _TapDebouncerState createState() => _TapDebouncerState();
@@ -54,21 +54,22 @@ class _TapDebouncerState extends State<TapDebouncer> {
       stream: _tapDebouncerHandler.busyStream,
       builder: (BuildContext context, AsyncSnapshot<bool> snapshot) {
         if (snapshot.hasError) {
-          throw StateError(
-              '_tapDebouncerHandler.busy has error=${snapshot.error}');
+          throw StateError('_tapDebouncerHandler.busy has error=${snapshot.error}');
         }
 
-        if (snapshot.hasData && !snapshot.data) {
+        if (snapshot.hasData && snapshot.data! == false) {
           return widget.builder(
             context,
             widget.onTap == null
                 ? null
                 : () async {
                     await _tapDebouncerHandler.onTap(() async {
-                      await widget.onTap();
+                      if (widget.onTap != null) {
+                        await widget.onTap!();
+                      }
 
                       if (widget.cooldown != null) {
-                        await Future<void>.delayed(widget.cooldown);
+                        await Future<void>.delayed(widget.cooldown!);
                       }
                     });
                   },
@@ -80,7 +81,7 @@ class _TapDebouncerState extends State<TapDebouncer> {
         if (widget.waitBuilder == null) {
           return disabledChild;
         } else {
-          return widget.waitBuilder(context, disabledChild);
+          return widget.waitBuilder!(context, disabledChild);
         }
       },
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,13 @@
 name: tap_debouncer
 description: Tap debounce simplifying widget. Wrap your button widget in TapDebounce widget and any taps will be disabled while tap callback is in progress.
-version: 1.0.1
+version: 2.0.0-nullsafety.2
 homepage: https://github.com/sla-000/flutter_debouncer
+repository: https://github.com/sla-000/flutter_debouncer
+authors:
+  - "Slava Ryabinin"
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
-  flutter: ^1.12.13
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   flutter:
@@ -14,8 +16,6 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-
-  pedantic: ^1.8.0+1
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
## Related Issue

#3 

## What was done

I took your changes from the null safety branch and made two modifications:

Include a null check for `.data` since that is also nullable, and `!snapshot.data!` would've looked kind of akward.

```dart
// from
if (snapshot.hasData && !snapshot.data) {
// to
if (snapshot.hasData && snapshot.data! == false) {
```

I think the code below `onTap!()` will not be executed if `onTap` is null, therefore I enclosed it with an if.
```dart
//from
await widget.onTap!();
// to
if (widget.onTap != null) {
  await widget.onTap!();
}
```

I then bumped the sdk requirement to 2.12 and removed the `pedantic` package, since it is no longer needed, and made some small beautifications to the pubspec.

I also updated the examples to no longer use Widgets, that have been deprecated.
