### PR TITLE
Change 'busy' state check to avoid initial widget blinking.

### DIFF
--- a/lib/src/debouncer_widget.dart
+++ b/lib/src/debouncer_widget.dart
@@ -60,7 +60,7 @@ class _TapDebouncerState extends State<TapDebouncer> {
 
         final bool isBusy = snapshot.data ?? false;
 
-        if (snapshot.hasData && !isBusy) {
+        if (!snapshot.hasData || !isBusy) {
           return widget.builder(
             context,
             widget.onTap == null


### PR DESCRIPTION
In my case, initial widget render is happening while stream is still empty, so `TapDebouncer` builds disabled child, passing `onTap == null`. Immediately after that, the child gets rebuilt. This creates 'blinking' effect on screen.

Proposed change should fix this issue.